### PR TITLE
Allow setting custom credentials for token auth

### DIFF
--- a/auth_options.go
+++ b/auth_options.go
@@ -43,7 +43,8 @@ type AuthOptions struct {
 	Username string `json:"username,omitempty"`
 	UserID   string `json:"-"`
 
-	Password string `json:"password,omitempty"`
+	Password         string `json:"password,omitempty"`
+	CustomCredential string `json:"customCredential,omitempty"`
 
 	// Passcode is used in TOTP authentication method
 	Passcode string `json:"passcode,omitempty"`

--- a/openstack/auth_env.go
+++ b/openstack/auth_env.go
@@ -47,6 +47,7 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 	applicationCredentialName := os.Getenv("OS_APPLICATION_CREDENTIAL_NAME")
 	applicationCredentialSecret := os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET")
 	systemScope := os.Getenv("OS_SYSTEM_SCOPE")
+	customCredential := os.Getenv("OS_CUSTOM_CREDENTIAL")
 
 	// If OS_PROJECT_ID is set, overwrite tenantID with the value.
 	if v := os.Getenv("OS_PROJECT_ID"); v != "" {
@@ -131,6 +132,7 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 		ApplicationCredentialName:   applicationCredentialName,
 		ApplicationCredentialSecret: applicationCredentialSecret,
 		Scope:                       scope,
+		CustomCredential:            customCredential,
 	}
 
 	return ao, nil

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -134,6 +134,7 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 		TenantName:       options.TenantName,
 		AllowReauth:      options.AllowReauth,
 		TokenID:          options.TokenID,
+		CustomCredential: options.CustomCredential,
 	}
 
 	result := tokens2.Create(v2Client, v2Opts)
@@ -167,6 +168,7 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 			return nil
 		}
 	}
+
 	client.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
 		return V2EndpointURL(catalog, opts)
 	}


### PR DESCRIPTION
Allows using the Rackspace API Key to set a custom credential with gophercloud. Since this is Rackspace specific: 

1. form the Json body of the Rackspace auth as a raw JSON message, and
2. Update gophercloud/utils and gophercloud/gophercloud to take in a custom auth format instead of password/token

Also depends on

https://github.com/platform9/gophercloud-utils/pull/1
and
https://github.com/platform9/cloud-provider-rackspace/pull/1